### PR TITLE
Use GLOB_RECURSE instead of GLOB when collecting all binaries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,14 +80,13 @@ install(CODE "execute_process(COMMAND ${BUILDEM_DIR}/tmp/relative-rpath.sh ${BUI
 install(CODE "execute_process(COMMAND ${BUILDEM_DIR}/tmp/relative-rpath.sh delete ${ilastik_SRC_DIR})")
 install(CODE "execute_process(COMMAND chrpath -r \\$ORIGIN/../lib ${BUILDEM_DIR}/bin/python2.7)")
 
-file(GLOB ALL_BIN_FILES "${BUILDEM_DIR}/bin/*")
+file(GLOB_RECURSE ALL_BIN_FILES "${BUILDEM_DIR}/bin/*")
 list(REMOVE_ITEM ALL_BIN_FILES "${BUILDEM_DIR}/bin/tests")
 
-INSTALL(PROGRAMS ${ALL_BIN_FILES}
-        DESTINATION bin)
+INSTALL(PROGRAMS ${ALL_BIN_FILES} DESTINATION bin)
 
 
-#INSTALL(PROGRAMS
+# INSTALL(PROGRAMS
 #    ${BUILDEM_DIR}/bin/ilastik_clusterized
 #    ${BUILDEM_DIR}/bin/ilastik_gui
 #    ${BUILDEM_DIR}/bin/ilastik_gui_test


### PR DESCRIPTION
Because on OSX 10.9 when compiling with GCC, python 2.7.6 creates a folder inside bin,
which CMake wants to copy like a file but that doesn't work.
